### PR TITLE
Add AGENTS.md with Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Bluenotes Social is a Community Notes-enabled fork of Bluesky. It's a React Native + Expo cross-platform app (iOS, Android, Web). The primary development target for cloud agents is the **web** build.
+
+### Environment
+
+This project uses **devbox** to manage development dependencies (Node.js, Yarn, Python, cmake, pkg-config, sqlite, clang, llvm). The Nix daemon must be running for devbox to work. All commands should be run through `devbox run --` to ensure the correct tool versions are available.
+
+Before running devbox commands, ensure the Nix daemon is running:
+```
+export PATH="/nix/var/nix/profiles/default/bin:$PATH"
+sudo /nix/var/nix/profiles/default/bin/nix-daemon &
+```
+
+### Key commands (all via `devbox run --`)
+
+| Task | Command |
+|------|---------|
+| Install deps | `devbox run -- yarn install` (also installs patches + i18n via postinstall) |
+| Install bskyembed deps | `devbox run -- bash -c "cd bskyembed && yarn install --frozen-lockfile"` |
+| Lint | `devbox run -- yarn lint` |
+| Typecheck | `devbox run -- yarn typecheck` |
+| Unit tests | `devbox run -- yarn test` |
+| Run web dev server | `devbox run -- yarn web` (serves on port 19006) |
+| Build i18n | `devbox run -- yarn intl:build` |
+
+### Caveats
+
+- The devbox `init_hook` in `devbox.json` runs `yarn` automatically when entering the devbox shell or running `devbox run`. This means running `devbox run -- <cmd>` will first run `yarn install` if needed.
+- 8 of 22 Jest test suites fail due to Expo native module resolution (`requireOptionalNativeModule`). This is expected in a web-only/non-native environment and is pre-existing.
+- The web dev server (Expo) listens on **port 19006** (webpack) and **port 8081** (Metro).
+- See `docs/build.md` for full build instructions and `docs/testing.md` for E2E test setup.
+- Sub-projects `bskyembed/`, `bskylink/`, `bskyogcard/`, and `bskyweb/` have their own `package.json` / dependencies. For web app development, only the root and `bskyembed` deps are needed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,22 +16,34 @@ export PATH="/nix/var/nix/profiles/default/bin:$PATH"
 sudo /nix/var/nix/profiles/default/bin/nix-daemon &
 ```
 
-### Key commands (all via `devbox run --`)
+### Key commands
+
+Prefer `just` commands (defined in the root `justfile`). Run through devbox: `devbox run -- just <recipe>`.
 
 | Task | Command |
 |------|---------|
-| Install deps | `devbox run -- yarn install` (also installs patches + i18n via postinstall) |
-| Install bskyembed deps | `devbox run -- bash -c "cd bskyembed && yarn install --frozen-lockfile"` |
-| Lint | `devbox run -- yarn lint` |
-| Typecheck | `devbox run -- yarn typecheck` |
+| Install deps | `devbox run -- just deps` |
+| Lint | `devbox run -- just lint` |
+| Typecheck | `devbox run -- just typecheck` |
+| Run web dev server | `devbox run -- just web` (serves on port 19006) |
 | Unit tests | `devbox run -- yarn test` |
-| Run web dev server | `devbox run -- yarn web` (serves on port 19006) |
 | Build i18n | `devbox run -- yarn intl:build` |
+| List all recipes | `devbox run -- just --list` |
+
+### Justfile recipes
+
+The `justfile` at the repo root defines: `lint`, `typecheck`, `web`, `deps`, `bskyweb`, `ios`, `ios-simulator`. Always use `just` when a recipe exists rather than calling yarn/npm directly.
+
+### Local backend (atproto dev environment)
+
+To run against a full local dev environment with a test PDS, clone the `open-community-notes` companion repo and run `just start` in it (it also uses devbox). Then on the social app sign-in page, click the edit (pencil) icon next to "Hosting provider" to point to the local PDS URL and login with `alice.test`.
 
 ### Caveats
 
-- The devbox `init_hook` in `devbox.json` runs `yarn` automatically when entering the devbox shell or running `devbox run`. This means running `devbox run -- <cmd>` will first run `yarn install` if needed.
+- The devbox `init_hook` in `devbox.json` runs `yarn` automatically when entering the devbox shell or running `devbox run`. This means running `devbox run -- just <cmd>` will first run `yarn install` if needed.
 - 8 of 22 Jest test suites fail due to Expo native module resolution (`requireOptionalNativeModule`). This is expected in a web-only/non-native environment and is pre-existing.
 - The web dev server (Expo) listens on **port 19006** (webpack) and **port 8081** (Metro).
+- Chrome "Aw, Snap!" crashes (Error code 4) can occur after long dev sessions due to accumulated memory. Fix by restarting the Expo server (`just web`) and opening a fresh Chrome tab.
+- Console shows CORS errors for `https://10.bsky.app/config` and React Native prop warnings (e.g., `accessibilityHint`, `hitSlop`). These are harmless in development.
 - See `docs/build.md` for full build instructions and `docs/testing.md` for E2E test setup.
 - Sub-projects `bskyembed/`, `bskylink/`, `bskyogcard/`, and `bskyweb/` have their own `package.json` / dependencies. For web app development, only the root and `bskyembed` deps are needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

### What's included

- **Devbox-based environment**: Documents that all commands should run through `devbox run --` to get correct Node.js, Yarn, and native build tool versions
- **Justfile-first workflow**: Documents `just` recipes (`lint`, `typecheck`, `web`, `deps`) as the primary command interface
- **Caveats**: Documents known issues (8/22 Jest suites fail on Expo native modules, CORS warnings in console, Chrome memory crashes after long sessions)
- **Backend setup**: Placeholder instructions for the `atproto-community-notes` companion repo

### Verified commands

| Check | Command | Result |
|-------|---------|--------|
| ✅ | `devbox run -- just lint` | 0 errors, 125 warnings |
| ✅ | `devbox run -- just typecheck` | Clean pass |
| ⚠️ | `devbox run -- yarn test` | 14/22 suites pass (pre-existing native module failures) |
| ✅ | `devbox run -- just web` | Serves on port 19006 |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8c18bbc-493a-4e3f-9f29-4e52c1f335eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8c18bbc-493a-4e3f-9f29-4e52c1f335eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

